### PR TITLE
build: remove mdx package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "dependencies": {
     "@docusaurus/core": "2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
-    "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",


### PR DESCRIPTION
> Docusaurus has built-in support for [MDX v1](https://mdxjs.com/)
https://docusaurus.io/docs/markdown-features/react

which means we don't need to install an additional package