### PR TITLE
add verfiyAndBuild action

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
     "format": "prettier --write .",
-    "verifyQuicklooks": "node scripts/verifyQuicklooks.js"
+    "verifyQuicklooks": "node scripts/verifyQuicklooks.js",
+    "verifyAndBuild": "yarn verifyQuicklooks && yarn build"
   },
   "dependencies": {
     "@docusaurus/core": "2.2.0",


### PR DESCRIPTION
I suggest that we merge this and then set verifyAndBuild as the default build task on vercel, so builds will fair if there's any broken QL links 