### PR TITLE
fix: update `editUrl` base path

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,7 +43,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/ArbitrumFoundation/docs/edit/main/docs',
+            'https://github.com/ArbitrumFoundation/docs/edit/main/',
         },
         blog: false,
         theme: {


### PR DESCRIPTION
currently links to 404 because of extra `/docs/` in base path

example link `Edit this page` on current docs:
https://github.com/ArbitrumFoundation/docs/edit/main/docs/docs/gentle-introduction-dao.md