### PR TITLE
chore: update fathom script src

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
   scripts: [
     // Fathom Analytics
     {
-      src: 'https://thirty-thirtyfour.arbitrum.foundation/script.js',
+      src: 'https://cdn.usefathom.com/script.js',
       'data-site': 'QLNDABBR',
       defer: true,
     },


### PR DESCRIPTION
Removes the custom domain script in favor of the standard script. Context: https://usefathom.com/changelog#mar2023