### PR TITLE
add current security council members page

### DIFF
--- a/docs/concepts/security-council.md
+++ b/docs/concepts/security-council.md
@@ -11,7 +11,7 @@ import DraftExpectationsPartial from '@site/docs/partials/_draft-expectations-pa
 
 <DraftExpectationsPartial />
 
-[The Constitution of the Arbitrum DAO](../dao-constitution) outlines the process for electing members to the <a data-quicklook-from='security-council'>Security Council</a>, a group of individuals who are responsible for addressing risks to the Arbitrum ecosystem through the selective application of <a data-quicklook-from='emergency-action'>emergency actions</a> and <a data-quicklook-from='nonemergency-action'>non-emergency actions</a>. The Security Council is made up of 12 members who are elected by the members of the Arbitrum DAO through a democratic process.
+[The Constitution of the Arbitrum DAO](../dao-constitution) outlines the process for electing members to the <a data-quicklook-from='security-council'>Security Council</a>, a group of individuals who are responsible for addressing risks to the Arbitrum ecosystem through the selective application of <a data-quicklook-from='emergency-action'>emergency actions</a> and <a data-quicklook-from='nonemergency-action'>non-emergency actions</a>. The Security Council is made up of 12 members who are elected by the members of the Arbitrum DAO through a democratic process. See [here](../security-council-members) for the current members of the Security Council.
 
 ### The role of the Security Council
 

--- a/docs/deployment-addresses.md
+++ b/docs/deployment-addresses.md
@@ -60,6 +60,8 @@ _*Note: the Token Distributor contract was [self-destructed](https://arbiscan.io
 | Security Council (L1, 9 of 12)      | Ethereum | <AEL address = {"0xF06E95eF589D9c38af242a8AAee8375f14023F85"} chainID = {1} />     |
 | Security Council (Nova, 9 of 12)    | Nova     | <AEL address = {"0xc232ee726E3C51B86778BB4dBe61C52cC07A60F3"} chainID = {42170} /> |
 
+_Note: See ["Security Council Members"](./security-council-members) for addresses of the current members of the Security Council._
+
 ### Security Council Elections
 
 | Contract                   | Chain    | Address                                                                            |

--- a/docs/foundational-documents/transparency-report-initial-foundation-setup.md
+++ b/docs/foundational-documents/transparency-report-initial-foundation-setup.md
@@ -69,6 +69,8 @@ The Security Council was required to be operational at the time the DAO launched
 
 The initial Security Council members, split by cohort, are as follows:
 
+_NOTE: The members list below represents the initial security council members, which are not necessarily the current members; for the list of current members, see [Security Council Members](../../security-council-members)._
+
 i. September Cohort
 
  1. [Mo Dong](https://twitter.com/no89thkey) is the Co-Founder of Celer Network. Mo received a PhD from the University of Illinois Urbana-Champaign in computer science.

--- a/docs/security-council-members.md
+++ b/docs/security-council-members.md
@@ -1,0 +1,40 @@
+---
+id: security-council-members
+title: 'Security Council Members'
+sidebar_label: Security Council Members
+description: Current members of the security council
+dao_author: dzgoldman
+dao_sme: dzgoldman
+---
+
+The following are the current members of the Security Council; for information about the Security Council, see ["Security Council Overview"](./concepts/security-council).
+
+i. September Cohort
+
+1.  [Matt Fiebach](https://twitter.com/MattFiebach)
+    - `0x3bd8e2ac65ad6f0f094ba6766cbd9484ab49ef23`
+2.  [Harry Kalodner](https://www.linkedin.com/in/hkalodner/) is Co-Founder and CTO at Offchain Labs. Harry started working on building Arbitrum while studying at Princeton University.
+    - `0xf8e1492255d9428c2Fc20A98A1DeB1215C8ffEfd`
+3.  [Patrick McCorry](https://twitter.com/stonecoldpat0) has spent most of his adult life working on cryptocurrencies and his time was split across academic research and industry. Before working at the Arbitrum Foundation, he has worked on transaction delivery, layer-2 protocols, atomic swaps, consensus protocols, and applied cryptography. In a past life, he was an Assistant Professor at King’s College London and an accomplished researcher at UCL, UIUC and NCL.
+    - `0x8f10e3413586c4a8dcfce19d009872b19e9cd8e3`
+4.  [0xhombre](https://twitter.com/0xhombre)
+    - `0xb71ca4ffbb7b58d75ba29891ab45e9dc12b444ed`
+5.  [John Morrow](https://twitter.com/jmo_mx)
+    - `0x3e286452b1c66abb08eb5494c3894f40ab5a59af`
+6.  [omer](https://twitter.com/omeragoldberg)
+    - `0xb07dc9103328a51128bc6cc1049d1137035f5e28`
+
+ii. March Cohort
+
+1.  [Patrick McNab](https://twitter.com/pat_mcnab) Is a Co-founder of Mycelium which has been developing and deploying decentralised financial infrastructure since 2018. Mycelium (previously Tracer DAO) were one of the first protocols deployed on Arbitrum in 2021 and support the Arbitrum ecosystem through running validators and Chainlink nodes.
+    - `0x566a07C3c932aE6AF74d77c29e5c30D8B1853710`
+2.  [Justin Drake](https://www.linkedin.com/in/drakefjustin) has been a researcher at the Ethereum Foundation since 2017. He focuses on Ethereum consensus layer upgrades.
+    - `0x5280406912EB8Ec677Df66C326BE48f938DC2e44`
+3.  [Bartek Kiepuszewski](https://www.linkedin.com/in/bartek-kiepuszewski-b3a299/?originalSubdomain=pl) has been a blockchain architect at MakerDAO since 2017. He also co-founded [l2beat.com](http://l2beat.com/) and TokenFlow Insights. Bartek holds a PhD in computer science from Queensland University of Technology.
+    - `0x0275b3D54a5dDbf8205A75984796eFE8b7357Bae`
+4.  [Rachel Bousfield](https://github.com/rachel-bousfield) has been a software engineer at Offchain Labs since 2021. She is currently leading the development of Stylus.
+    - `0x5A1FD562271aAC2Dadb51BAAb7760b949D9D81dF`
+5.  [Patricio Worthalter](https://www.linkedin.com/in/worthalter/?originalSubdomain=ar) has been working full time in the Ethereum space since 2015. In 2018 he founded POAP, a web3 native public good that mints digital collectibles for the preservation of memories.
+    - `0xf6B6F07862A02C85628B3A9688beae07fEA9C863`
+6.  [Yoav Weiss](https://twitter.com/yoavw) is a security researcher at the Ethereum Foundation and has been building in the Ethereum space since 2017, working on account abstraction (ERC-4337), OpenGSN, L2 security, etc. Yoav brings over 25 years of experience and has developed security technologies used by industry leading companies.
+    - `0x475816ca2a31D601B4e336f5c2418A67978aBf09`

--- a/sidebars.js
+++ b/sidebars.js
@@ -102,6 +102,10 @@ module.exports = {
       label: 'Governance architecture',
       items: [
         {
+          type: 'doc',
+          id: 'security-council-members',
+        },
+        {
           type: 'link',
           label: 'Sybil detection',
           href: 'https://github.com/ArbitrumFoundation/sybil-detection',


### PR DESCRIPTION
TODO:
- [ ] After [election ends](https://www.tally.xyz/gov/arbitrum/council/security-council/election/0/round-2) on 10/27, double check that members listed here are indeed the winners of the September 2023 election
- [ ] Get 1-2 sentence bios from all members
- [ ] Merge only after member update is effectuated, not after election is over (effectuation will be on ~11/9) 