### PR TITLE
docs: add explicit durations for phases on AIP lifecycle page

### DIFF
--- a/docs/concepts/lifecycle-anatomy-aip-proposal.md
+++ b/docs/concepts/lifecycle-anatomy-aip-proposal.md
@@ -50,7 +50,7 @@ graph TD;
   B -->|"<span style='padding: 3px;'>Passes</span>"| C["<a href='#phase-2-formal-aip-and-call-for-voting' style='text-decoration:none;'><b>Phase 2: Formal AIP and call for voting</b></a><br/><span style='font-size:smaller'>(3 days)</span>"];
   C -->|"<span style='padding: 3px;'>Passes</span>"| D["<a href='#phase-3-on-chain-dao-vote' style='text-decoration:none;'><b>Phase 3: On-chain DAO vote</b></a><br/><span style='font-size:smaller'>(14 days, extendable by 2 days)</span>"];
   D -->|"<span style='padding: 3px;'>Passes, Constitutional AIP</span>"| E["<a href='#phase-4-l2-waiting-period' style='text-decoration:none;'><b>Phase 4: L2 waiting period</b></a><br/><span style='font-size:smaller'>(3 days)</span>"];
-  E --> F["<a href='#phase-5-l2-to-l1-message' style='text-decoration:none;'><b>Phase 5: L2-to-L1 message</b></a>"];
+  E --> F["<a href='#phase-5-l2-to-l1-message' style='text-decoration:none;'><b>Phase 5: L2-to-L1 message</b></a><br/><span style='font-size:smaller'>(1 week)</span>"];
   F --> G["<a href='#phase-6-l1-waiting-period' style='text-decoration:none;'><b>Phase 6: L1 waiting period</b></a><br/><span style='font-size:smaller'>(3 days)</span>"];
   G --> H["<a href='#additional-waiting-periods-optional' style='text-decoration:none;'><b>Optional waiting period</b></a>"];
   D -->|"<span style='padding: 3px;'>Passes, Non-Constitutional AIP</span>"| H["<a href='#additional-waiting-periods-optional' style='text-decoration:none;'><b>Optional waiting period</b></a>"];
@@ -58,7 +58,7 @@ graph TD;
 ```
 
 
-#### Phase 1: Temperature check (optional but recommended)
+#### Phase 1: Temperature check (optional but recommended) - 1 week in duration
 
 This is the first phase of the Arbitrum Improvement Proposal (AIP) process: 
 
@@ -71,30 +71,30 @@ This is the first phase of the Arbitrum Improvement Proposal (AIP) process:
 This is an optional step, but it's recommended as a due-diligence governance best practice. If an AIP fails this temperature check, the original AIP author is encouraged to refrain from proceeding, and voters are encouraged to reject it if the author proceeds. If an AIP proposer decides to skip this step, voters should consider this as a factor in their vote.
 
 
-#### Phase 2: Formal AIP and call for voting
+#### Phase 2: Formal AIP and call for voting - 3 days in duration
 
 In this phase, the AIP is officially submitted via governance smart contracts on the Arbitrum One chain. The proposer of the AIP must have an address that can represent at least 1,000,000 votable tokens. After the AIP is submitted, there's a 3-day period for interested parties to discuss the proposal and gather votes before a voter distribution snapshot is taken. During this phase, the AIP must be labeled as either <a data-quicklook-from='constitutional-aip'>Constitutional</a> or <a data-quicklook-from='nonconstitutional-aip'>Non-Constitutional</a>. Additionally, the AIP must clearly specify which Arbitrum DAO-governed chain(s) it will affect. This phase is important as it defines a clear, formal protocol for proposing and voting on AIPs.
 
 
-#### Phase 3: On-chain DAO vote
+#### Phase 3: On-chain DAO vote - 14 days in duration
 
 During this phase, members of the Arbitrum DAO can vote directly on-chain for (or against) a submitted AIP. For the AIP to pass, more Votable Tokens must vote in favor than against, and a certain percentage of all Votable Tokens must vote in favor. This percentage is 5% for Constitutional AIPs and 3% for Non-Constitutional AIPs, and is referred to as "Threshold 2" within the [Constitution](../dao-constitution.md).
 
 The voting period for an AIP ends 14 days after it starts. However, if Threshold 2 is reached within the last 2 days of the voting period, the voting period is extended by 2 days. If the AIP fails to pass, the process ends after this Phase 3. If it does pass, Constitutional AIPs move on to Phases 4 through 7, while Non-Constitutional AIPs skip Phases 4 through 6 and go straight to Phase 7.
 
-#### Phase 4: L2 waiting period
+#### Phase 4: L2 waiting period - 3 days in duration
 
 After an AIP passes Phase 3 of the voting process, there is a 3-day waiting period known as Phase 4. During this time, people who do not agree with the AIP have the chance to withdraw their funds or take other action on L2. This period is meant to give everyone time to consider the decision and make any necessary adjustments to their investments or actions.
 
 Once the 3-day waiting period is over, the AIP will move on to the next phase of the voting process, as long as no major issues arise. This waiting period is important because it ensures that everyone has an opportunity to voice their concerns and recalibrate their participation before the AIP is finalized.
 
-#### Phase 5: L2-to-L1 message
+#### Phase 5: L2-to-L1 message - 1 week in duration
 
 Once the 3-day waiting period of Phase 4 has passed and an AIP has been approved, Phase 5 of the voting process begins. In this phase, an [L2-to-L1 message](https://developer.arbitrum.io/arbos/l2-to-l1-messaging) is sent indicating that the AIP has passed. This message is sent to L1, which is the main Ethereum blockchain. Once the message is finalized on L1 (this takes at least 1 week), anyone can redeem it to complete this step and move on to the next step of the process. This ensures that the completion of the L2 waiting period will be recognized on L1 after any withdrawals initiated during or soon after the voting period have been recognized on L1.
 
 This phase is important because it connects the Arbitrum blockchain, which is a Layer 2 (or L2) blockchain, to the main Ethereum blockchain, which is the L1 chain. This connection gives DAO members a guarantee that the DAO's decision (and its members' votes) is immutably recorded. This is an important step in the process of decentralized decision-making because it ensures that everyone can trust-but-verify the outcome of the voting process.
 
-#### Phase 6: L1 waiting period
+#### Phase 6: L1 waiting period - 3 days in duration
 
 After Phase 5 of the voting process, where the decision is recorded on the Ethereum mainnet, the process enters Phase 6, which is a 3-day waiting period. This waiting period ensures that in-progress transactions have enough time to finalize on mainnet before the AIP is implemented.
 


### PR DESCRIPTION
this PR does two things:
- adds the duration of phase 5 into the diagram, bringing it in-line with how the other phases on the diagram have a duration
- adds the duration of each phase explicitly in the reference sections in text