### PR TITLE
docs: add network upgrade status information to docs

### DIFF
--- a/docs/network-upgrades.md
+++ b/docs/network-upgrades.md
@@ -21,7 +21,7 @@ Visit [Inside Arbitrum Nitro](https://docs.arbitrum.io/inside-arbitrum-nitro/) t
 | ArbOS 20 "Atlas"                                                      | [vote on-going](https://www.tally.xyz/gov/arbitrum/proposal/46905320292877192134536823079608810426433248493109520384601548724615383601450?chart=bubble)  | TBD | TBD | TBD |
 | [ArbOS 11](https://github.com/OffchainLabs/nitro/releases/tag/v2.2.0) | [approved & executed](https://www.tally.xyz/gov/arbitrum/proposal/77069694702187027448745871790562515795432836429094222862498991082283032976814)  | Tues, 2024-01-30 at 17:00:00 UTC | Thu, 2024-02-24 at 20:01:13 UTC (`1706817673`) | Thu, 2024-02-24 at 20:01:13 UTC (`1706817673`) |
 
-### Stay up to date with the latest information on the status of network upgrades
+### Stay up to date
 To stay up to date with proposals, timelines, and statuses of network upgrades to Arbitrum One and Nova:
 - Subscribe to the [Arbitrum Node Upgrade Announcement channel on Telegram](https://t.me/arbitrumnodeupgrade)
 - Join both the `#dev-announcements` and `#node-runners` Discord channels in the [Arbitrum Discord server](https://discord.gg/arbitrum)

--- a/docs/network-upgrades.md
+++ b/docs/network-upgrades.md
@@ -1,0 +1,28 @@
+---
+id: network-upgrades
+title: Network upgrades
+sidebar_label: Network upgrades
+---
+
+:::info PUBLIC PREVIEW DOCUMENT
+
+This document is currently in **<a href='/concepts/public-preview-content'>public preview</a>** and may change significantly as feedback is captured from readers like you. Click the *Request an update* button at the top of this document or [join the Arbitrum Discord](https://discord.gg/arbitrum) to share your feedback.
+
+:::
+
+This page has information on the state and timelines of major software updates to Arbitrum One and Arbitrum Nova. Software updates that alter an Arbitrum chain's ability to produce valid Arbitrum blocks are referred to as ArbOS upgrades and, as outlined in the [Arbitrum DAO Constitution](./dao-constitution.md), will always require a Constiutional AIP to pass for DAO-governed chains.
+
+Visit [Inside Arbitrum Nitro](https://docs.arbitrum.io/inside-arbitrum-nitro/) to learn more about Nitro's architecture; more information about ArbOS software releases is available on the [Arbitrum DAO forum](https://forum.arbitrum.foundation/t/arbitrum-arbos-upgrades/19695).
+
+## Activations
+
+| Upgrade                 | Governance Approval Status | Arbitrum Sepolia                                 | Arbitrum One                                    | Arbitrum Nova                                      |
+| -------------------------- | ------------------- | ---------------------------------------------- | ---------------------------------------------- | ---------------------------------------------- |
+| ArbOS 20 "Atlas"                                                      | [vote on-going](https://www.tally.xyz/gov/arbitrum/proposal/46905320292877192134536823079608810426433248493109520384601548724615383601450?chart=bubble)  | TBD | TBD | TBD |
+| [ArbOS 11](https://github.com/OffchainLabs/nitro/releases/tag/v2.2.0) | [approved & executed](https://www.tally.xyz/gov/arbitrum/proposal/77069694702187027448745871790562515795432836429094222862498991082283032976814)  | Tues, 2024-01-30 at 17:00:00 UTC | Thu, 2024-02-24 at 20:01:13 UTC (`1706817673`) | Thu, 2024-02-24 at 20:01:13 UTC (`1706817673`) |
+
+### Stay up to date with the latest information on the status of network upgrades
+To stay up to date with proposals, timelines, and statuses of network upgrades to Arbitrum One and Nova:
+- Subscribe to the [Arbitrum Node Upgrade Announcement channel on Telegram](https://t.me/arbitrumnodeupgrade)
+- Join both the `#dev-announcements` and `#node-runners` Discord channels in the [Arbitrum Discord server](https://discord.gg/arbitrum)
+- Follow the official Arbitrum ([`@Arbitrum`](https://twitter.com/arbitrum)) and Arbitrum Developers ([`@ArbitrumDevs`](https://twitter.com/ArbitrumDevs)) X accounts, formerly Twitter.

--- a/docs/network-upgrades.md
+++ b/docs/network-upgrades.md
@@ -4,11 +4,11 @@ title: Network upgrades
 sidebar_label: Network upgrades
 ---
 
-:::info PUBLIC PREVIEW DOCUMENT
+import DraftExpectationsPartial from '@site/docs/partials/_draft-expectations-partial.md'; 
 
-This document is currently in **<a href='/concepts/public-preview-content'>public preview</a>** and may change significantly as feedback is captured from readers like you. Click the *Request an update* button at the top of this document or [join the Arbitrum Discord](https://discord.gg/arbitrum) to share your feedback.
+<DraftExpectationsPartial />
 
-:::
+
 
 This page has information on the state and timelines of major software updates to Arbitrum One and Arbitrum Nova. Software updates that alter an Arbitrum chain's ability to produce valid Arbitrum blocks are referred to as ArbOS upgrades and, as outlined in the [Arbitrum DAO Constitution](./dao-constitution.md), will always require a Constiutional AIP to pass for DAO-governed chains.
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,6 +33,10 @@ module.exports = {
       id: 'new-arb-chains',
     },
     {
+      type: 'doc',
+      id: 'network-upgrades',
+    },
+    {
       type: 'category',
       label: 'How-to guides',
       collapsed: false,


### PR DESCRIPTION
This PR adds a page describing the status of network upgrades on Arbitrum One, Arbitrum Nova, and Arbitrum Sepolia. I've also included references to the actual releases, relevant explainers, and channels to monitor to stay in the loop about upgrades.