### PR TITLE
fix(cms): clear governance publishing flow, remove failing publish button

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -156,11 +156,9 @@
             if (oy === "auto" || oy === "scroll") return el;
             el = el.parentElement;
           }
-          return (
-            document.querySelector('[class*="ControlPaneContainer"]') ||
-            document.querySelector('[class*="EditorContainer"]') ||
-            document.getElementById("nc-root")
-          );
+          // only the real scrollable editing column; never fall back to
+          // #nc-root, which the absolutely-positioned editor covers
+          return document.querySelector('[class*="ControlPaneContainer"]') || null;
         }
 
         function ensureFlowBanner() {
@@ -168,13 +166,16 @@
           var inEditor = /\/collections\/[^/]+\/(entries\/|new)/.test(hash);
           var existing = document.getElementById("af-flow-banner");
           if (!inEditor) {
-            if (existing) existing.parentNode.removeChild(existing);
+            if (existing && existing.parentNode) existing.parentNode.removeChild(existing);
             return;
           }
-          if (existing) return;
 
           var pane = findEditPane();
           if (!pane) return;
+          if (existing) {
+            if (existing.parentNode === pane) return;
+            if (existing.parentNode) existing.parentNode.removeChild(existing);
+          }
 
           var banner = document.createElement("div");
           banner.id = "af-flow-banner";

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -93,10 +93,6 @@
         opacity: 0.9 !important;
       }
 
-      [class*="PublishButton"] {
-        display: none !important;
-      }
-
       [class*="EntryListing"] a {
         border-left: 3px solid transparent !important;
       }
@@ -130,23 +126,46 @@
     </script>
     <script>
       (function () {
+        // hide the publish / republish control in the editorial-workflow toolbar.
+        // decap renders publish, status and save as the same styled component, so
+        // we discriminate by visible label: hide "publish" / "published" actions,
+        // never "save" or "status: ...". scoped to the toolbar so banner copy is safe.
         function hidePublishControl() {
-          var byClass = document.querySelectorAll('[class*="PublishButton"]');
-          for (var i = 0; i < byClass.length; i++) {
-            byClass[i].style.display = "none";
-          }
-          var buttons = document.querySelectorAll("#nc-root button");
-          for (var j = 0; j < buttons.length; j++) {
-            var label = (buttons[j].textContent || "").trim().toLowerCase();
-            if (label.indexOf("unpublish") === -1 && label.indexOf("publish") === 0) {
-              buttons[j].style.display = "none";
+          var toolbar = document.querySelector('[class*="ToolbarContainer"]');
+          if (!toolbar) return;
+          var controls = toolbar.querySelectorAll('[class*="StyledDropdownButton"], button');
+          for (var i = 0; i < controls.length; i++) {
+            var label = (controls[i].textContent || "").trim().toLowerCase();
+            if (label.indexOf("publish") === 0) {
+              var wrap =
+                controls[i].closest('[class*="ToolbarDropdown"]') ||
+                controls[i].closest('[class*="StyledWrapper"]') ||
+                controls[i];
+              wrap.style.display = "none";
             }
           }
         }
 
+        function findEditPane() {
+          var anchor = document.querySelector(
+            '#nc-root input, #nc-root textarea, #nc-root [data-slate-editor]',
+          );
+          var el = anchor;
+          while (el && el !== document.body) {
+            var oy = getComputedStyle(el).overflowY;
+            if (oy === "auto" || oy === "scroll") return el;
+            el = el.parentElement;
+          }
+          return (
+            document.querySelector('[class*="ControlPaneContainer"]') ||
+            document.querySelector('[class*="EditorContainer"]') ||
+            document.getElementById("nc-root")
+          );
+        }
+
         function ensureFlowBanner() {
           var hash = window.location.hash || "";
-          var inEditor = /\/collections\/.+\/entries\//.test(hash);
+          var inEditor = /\/collections\/[^/]+\/(entries\/|new)/.test(hash);
           var existing = document.getElementById("af-flow-banner");
           if (!inEditor) {
             if (existing) existing.parentNode.removeChild(existing);
@@ -154,11 +173,14 @@
           }
           if (existing) return;
 
+          var pane = findEditPane();
+          if (!pane) return;
+
           var banner = document.createElement("div");
           banner.id = "af-flow-banner";
           banner.style.cssText =
             "background:#213147;color:#fff;border-left:4px solid #12AAFF;" +
-            "border-radius:2px;padding:16px 20px;margin:16px;font-size:14px;line-height:1.5;";
+            "border-radius:2px;padding:16px 20px;margin:16px 0;font-size:14px;line-height:1.5;";
           banner.innerHTML =
             "<strong>how publishing works here</strong>" +
             "<ol style='margin:8px 0 8px 18px;padding:0;'>" +
@@ -168,13 +190,7 @@
             "</ol>" +
             "<em>there is no publish button by design, publishing happens after approval</em>";
 
-          var toolbar = document.querySelector('[class*="EditorToolbar"]');
-          var root = document.getElementById("nc-root");
-          if (toolbar && toolbar.parentNode) {
-            toolbar.parentNode.insertBefore(banner, toolbar.nextSibling);
-          } else if (root) {
-            root.insertBefore(banner, root.firstChild);
-          }
+          pane.insertBefore(banner, pane.firstChild);
         }
 
         var observer = new MutationObserver(function () {

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -185,8 +185,8 @@
           banner.innerHTML =
             "<strong>how publishing works here</strong>" +
             "<ol style='margin:8px 0 8px 18px;padding:0;'>" +
-            "<li>edit your page and click <strong>save</strong> so your change is saved automatically as a pull request</li>" +
-            "<li>use the <strong>status</strong> menu to move it from <strong>draft</strong> to <strong>in review</strong> for team feedback then to <strong>ready</strong></li>" +
+            "<li>edit your page and click <strong>save</strong> to save your change as a pull request</li>" +
+            "<li><strong>after saving</strong>, a <strong>status</strong> menu appears, use it to move from <strong>draft</strong> to <strong>in review</strong> for team feedback then to <strong>ready</strong></li>" +
             "<li>marking it <strong>ready</strong> submits it for approval and a maintainer reviews and publishes it so you are done</li>" +
             "</ol>" +
             "<em>there is no publish button by design, publishing happens after approval</em>";

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -144,11 +144,47 @@
           }
         }
 
+        function ensureFlowBanner() {
+          var hash = window.location.hash || "";
+          var inEditor = /\/collections\/.+\/entries\//.test(hash);
+          var existing = document.getElementById("af-flow-banner");
+          if (!inEditor) {
+            if (existing) existing.parentNode.removeChild(existing);
+            return;
+          }
+          if (existing) return;
+
+          var banner = document.createElement("div");
+          banner.id = "af-flow-banner";
+          banner.style.cssText =
+            "background:#213147;color:#fff;border-left:4px solid #12AAFF;" +
+            "border-radius:2px;padding:16px 20px;margin:16px;font-size:14px;line-height:1.5;";
+          banner.innerHTML =
+            "<strong>how publishing works here</strong>" +
+            "<ol style='margin:8px 0 8px 18px;padding:0;'>" +
+            "<li>edit your page and click <strong>save</strong> so your change is saved automatically as a pull request</li>" +
+            "<li>use the <strong>status</strong> menu to move it from <strong>draft</strong> to <strong>in review</strong> for team feedback then to <strong>ready</strong></li>" +
+            "<li>marking it <strong>ready</strong> submits it for approval and a maintainer reviews and publishes it so you are done</li>" +
+            "</ol>" +
+            "<em>there is no publish button by design, publishing happens after approval</em>";
+
+          var toolbar = document.querySelector('[class*="EditorToolbar"]');
+          var root = document.getElementById("nc-root");
+          if (toolbar && toolbar.parentNode) {
+            toolbar.parentNode.insertBefore(banner, toolbar.nextSibling);
+          } else if (root) {
+            root.insertBefore(banner, root.firstChild);
+          }
+        }
+
         var observer = new MutationObserver(function () {
           hidePublishControl();
+          ensureFlowBanner();
         });
         observer.observe(document.body, { childList: true, subtree: true });
+        window.addEventListener("hashchange", ensureFlowBanner);
         hidePublishControl();
+        ensureFlowBanner();
       })();
     </script>
   </body>

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -82,7 +82,6 @@
         font-weight: 600 !important;
       }
 
-      button[class*="PublishButton"],
       button[class*="ToolbarButton"] {
         background: var(--arb-blue) !important;
         color: #fff !important;
@@ -90,9 +89,12 @@
         border-radius: 2px !important;
       }
 
-      button[class*="SaveButton"],
-      button[class*="PublishButton"]:hover {
+      button[class*="SaveButton"]:hover {
         opacity: 0.9 !important;
+      }
+
+      [class*="PublishButton"] {
+        display: none !important;
       }
 
       [class*="EntryListing"] a {
@@ -125,6 +127,29 @@
           config.load_config_file = false;
           window.CMS.init({ config: config });
         });
+    </script>
+    <script>
+      (function () {
+        function hidePublishControl() {
+          var byClass = document.querySelectorAll('[class*="PublishButton"]');
+          for (var i = 0; i < byClass.length; i++) {
+            byClass[i].style.display = "none";
+          }
+          var buttons = document.querySelectorAll("#nc-root button");
+          for (var j = 0; j < buttons.length; j++) {
+            var label = (buttons[j].textContent || "").trim().toLowerCase();
+            if (label.indexOf("unpublish") === -1 && label.indexOf("publish") === 0) {
+              buttons[j].style.display = "none";
+            }
+          }
+        }
+
+        var observer = new MutationObserver(function () {
+          hidePublishControl();
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+        hidePublishControl();
+      })();
     </script>
   </body>
 </html>


### PR DESCRIPTION
## what

makes the decap cms governance publishing flow clear so non-technical writers never hit the protected-branch merge error.

## why

`main` is protected and requires a pull request review. decap's "publish" button tries to merge the entry's pr directly via the github api, which branch protection correctly rejects, surfacing a red `API_ERROR: Changes must be made through a pull request` to writers. this looked broken and caused confusion.

decap has no native way to couple its review step to a vcs approval gate (decaporg/decap-cms#7200), and it opens the pr automatically on first save, so the write → review → ready flow already lives in the cms. the only problem is the publish button.

## what changed

all in `static/admin/index.html`:

- hide the publish control (css + a js safety net for class-name drift). save, the status dropdown, and "delete unpublished changes" are untouched
- inject an on-brand banner into the editor view explaining the flow: edit → save → move to ready → a maintainer approves and publishes

no `config.yml` change, no github actions, no cms migration. editorial workflow and native on-save pr creation are unchanged.

## writer flow after this

1. edit a page and click save (decap opens a pr automatically)
2. move status draft → in review → ready
3. a maintainer reviews and merges the pr; the required approval gate is unchanged

## note for repo settings

enabling "automatically delete head branches" keeps merged entries from lingering in the cms "ready" column (decaporg/decap-cms#1592). this is a repo setting, intentionally not part of this pr.

## verification

on a preview deploy `/admin/`: confirm the publish button is gone, save/status/delete remain, the banner renders only in the editor, and marking an entry ready produces a pr with no error.
